### PR TITLE
Remove 'api' from `bob_url`

### DIFF
--- a/src/wendy/commands.clj
+++ b/src/wendy/commands.clj
@@ -23,7 +23,7 @@
 (defn bob-url
   []
   (let [{:keys [host port]} (:connection (conf/read-conf))]
-    (format "http://%s:%d/api" host port)))
+    (format "http://%s:%d" host port)))
 
 (defn can-we-build-it!
   []


### PR DESCRIPTION
A small fix in order to be able to run commands from wendy. I discovered and fixed it in order to be able to run the Getting started tutorial for Bob (https://bob-cd.github.io/pages/getting-started.html).

By the way, nice idea and good job! :)