### PR TITLE
fix: #23 optional request body

### DIFF
--- a/src/wendy/spec.clj
+++ b/src/wendy/spec.clj
@@ -43,11 +43,12 @@
   (let [args (map #(param->arg schema %) params)]
     (if request-body
       (conj args
-            {:option  "f"
+            {:option  "data"
              :as      (request-body "description")
-             :default :present
              :in      :body
-             :type    :slurp})
+             :type    :slurp
+             :default (when (request-body "required")
+                        :present)})
       args)))
 
 (defn path-data->op


### PR DESCRIPTION
Request bodies were always required though they were in fact optional